### PR TITLE
IST-8 SDCARD by interruption

### DIFF
--- a/arch/arm/boot/dts/imx6ull-var-dart.dtsi
+++ b/arch/arm/boot/dts/imx6ull-var-dart.dtsi
@@ -46,6 +46,7 @@
         	spi-max-frequency = <50000000>;
 		voltage-ranges = <3300 3300>;
 		reg = <0>;
+		gpios = <&gpio4 24 GPIO_ACTIVE_LOW>;
 	};
 };
 
@@ -83,6 +84,7 @@
 				MX6UL_PAD_CSI_DATA06__ECSPI1_MOSI       0x100b1
 				MX6UL_PAD_CSI_DATA04__ECSPI1_SCLK       0x100b1
 				MX6UL_PAD_CSI_DATA05__GPIO4_IO26        0x100b1
+				MX6UL_PAD_CSI_DATA03__GPIO4_IO24        0x100b1 /* CD_SPI_SD */
 			>;
 		};
 	};

--- a/drivers/mmc/host/of_mmc_spi.c
+++ b/drivers/mmc/host/of_mmc_spi.c
@@ -132,7 +132,7 @@ struct mmc_spi_platform_data *mmc_spi_get_pdata(struct spi_device *spi)
 	if (oms->detect_irq != 0) {
 		oms->pdata.init = of_mmc_spi_init;
 		oms->pdata.exit = of_mmc_spi_exit;
-	} else {
+	} else if (!gpio_is_valid(oms->gpios[CD_GPIO])){
 		oms->pdata.caps |= MMC_CAP_NEEDS_POLL;
 	}
 


### PR DESCRIPTION
Enable SDCARD card detect by interruption instead of polling.

Signed-off-by: Josep Orga <jorga@somdevices.com>