### PR TITLE
HE675-Expose Amp Switch GPIO

### DIFF
--- a/arch/arm/boot/dts/imx6ul-imx6ull-var-dart-common.dtsi
+++ b/arch/arm/boot/dts/imx6ul-imx6ull-var-dart-common.dtsi
@@ -588,6 +588,8 @@
 				/*MX6UL_PAD_LCD_DATA17__GPIO3_IO22		0x40000000 Sample to get feedback from grpio sysfs*/
 				/*-------------------------------BD7181x--------------------------------*/
 				MX6UL_PAD_ENET2_TX_DATA1__GPIO2_IO12    0x1b0b0 /* PMICIO.INT_OUT */
+				/*-------------------------------audio switch--------------------------------*/				
+				MX6UL_PAD_JTAG_TCK__GPIO1_IO14			0x1b0b0
 			>;			
 		};
 


### PR DESCRIPTION
Con motivo de las nuevas placas con booster, hay que encender apagar el switch del amplificador cada vez que reproduzcamos un audio, si no hay un consumo extra.